### PR TITLE
[iOS] Add more automation test cases

### DIFF
--- a/iOS/MSQAAutomationApp/AppDelegate.h
+++ b/iOS/MSQAAutomationApp/AppDelegate.h
@@ -34,6 +34,6 @@
 
 @property(nonatomic) FakeMSALPublicClientApplication *application;
 
-@property(nonatomic) MSQASignInClient *msSignIn;
+@property(nonatomic) MSQASignInClient *msSignInClient;
 
 @end

--- a/iOS/MSQAAutomationApp/AppDelegate.m
+++ b/iOS/MSQAAutomationApp/AppDelegate.m
@@ -38,12 +38,13 @@
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   MSQAConfiguration *config = [[MSQAConfiguration alloc]
       initWithClientID:@"c4e50099-e6cd-43e4-a7c6-ffb3cebce505"];
-  _msSignIn = [[MSQASignInClient alloc]
+  _msSignInClient = [[MSQASignInClient alloc]
       initWithConfiguration:config
                         cls:[FakeMSALPublicClientApplication class]
                       error:nil];
   ;
-  _application = (FakeMSALPublicClientApplication *)[_msSignIn getApplication];
+  _application =
+      (FakeMSALPublicClientApplication *)[_msSignInClient getApplication];
 
   return YES;
 }

--- a/iOS/MSQAAutomationApp/Base.lproj/Main.storyboard
+++ b/iOS/MSQAAutomationApp/Base.lproj/Main.storyboard
@@ -17,14 +17,54 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Beg-mZ-PJa">
+                                <rect key="frame" x="66" y="459" width="266" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="get current account after signin"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Get current account after signin"/>
+                                <connections>
+                                    <action selector="getCurrentAccountAfterSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bXa-qg-Gx9"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pyt-OL-2QU">
+                                <rect key="frame" x="64" y="431" width="288" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="fetch token interactive with cancel"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Fetch token interactive with cancel"/>
+                                <connections>
+                                    <action selector="fetchTokenInteractiveWithPromptCanceled:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yMr-LZ-Z8l"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lih-Yo-XZT">
+                                <rect key="frame" x="100" y="401" width="198" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="fetch token interactive"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Fetch token interactive"/>
+                                <connections>
+                                    <action selector="fetchTokenInteractiveWithPromptAccepted:" destination="BYZ-38-t0r" eventType="touchUpInside" id="El8-m1-z24"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9UX-3J-RpU">
-                                <rect key="frame" x="101" y="599" width="215" height="31"/>
+                                <rect key="frame" x="74" y="599" width="251" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" identifier="fetch token silent after signin"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Fetch token silent after signin"/>
                                 <connections>
                                     <action selector="fetchTokenSilentAfterSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aRJ-Ch-w20"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JUK-Se-Sj4">
+                                <rect key="frame" x="61" y="570" width="291" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="fetch token silent before signin"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Fetch token silent before signin"/>
+                                <connections>
+                                    <action selector="fetchTokenSilentBeforeSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sg8-91-c00"/>
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="VEo-jz-JbL">
@@ -37,16 +77,6 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JUK-Se-Sj4">
-                                <rect key="frame" x="94" y="588" width="227" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <accessibility key="accessibilityConfiguration" identifier="fetch token silent before signin"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Fetch token silent before signin"/>
-                                <connections>
-                                    <action selector="fetchTokenSilentBeforeSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sg8-91-c00"/>
-                                </connections>
-                            </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tmj-xi-g4w">
                                 <rect key="frame" x="88" y="734" width="240" height="128"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -57,18 +87,72 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Ig-Mh-c2M">
+                                <rect key="frame" x="61" y="486" width="280" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="get current account before signin"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Get current account before signin"/>
+                                <connections>
+                                    <action selector="getCurrentAccountBeforeSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pZa-Wn-e7P"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QHQ-Hn-fMw">
+                                <rect key="frame" x="155" y="539" width="92" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="sign out"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Sign out "/>
+                                <connections>
+                                    <action selector="signOut:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m7l-fy-hlH"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TC2-NS-c68">
+                                <rect key="frame" x="116" y="375" width="168" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="sign in with accept"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Sign in with accept"/>
+                                <connections>
+                                    <action selector="signInWithPromptAccepted:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QYJ-JI-MN2"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Lv-Pf-Syh">
+                                <rect key="frame" x="117" y="351" width="166" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" identifier="sign in with cancel"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Sign in with cancel"/>
+                                <connections>
+                                    <action selector="signInWithPromptCanceled:" destination="BYZ-38-t0r" eventType="touchUpInside" id="KKU-N7-IPr"/>
+                                </connections>
+                            </button>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vLs-zT-IMs" customClass="MSQASignInButton">
+                                <rect key="frame" x="92" y="221" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ms button sign in with accept"/>
+                            </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qcf-iN-IKi" customClass="MSQASignInButton">
+                                <rect key="frame" x="92" y="85" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ms button sign in with cancel"/>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
+                        <outlet property="msSignInButtonAccepted" destination="vLs-zT-IMs" id="6C7-th-NW2"/>
+                        <outlet property="msSignInButtonCanceled" destination="qcf-iN-IKi" id="n0f-za-Qfc"/>
                         <outlet property="resultInfo" destination="VEo-jz-JbL" id="Uqu-uv-ukt"/>
                         <outlet property="resultStatus" destination="Tmj-xi-g4w" id="bNf-Po-azi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-23" y="44"/>
+            <point key="canvasLocation" x="-23.188405797101453" y="43.526785714285715"/>
         </scene>
     </scenes>
     <resources>

--- a/iOS/MSQAAutomationApp/FakeDataProvider.h
+++ b/iOS/MSQAAutomationApp/FakeDataProvider.h
@@ -32,9 +32,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Provides the testing account that is deserialized from strings defined in
-/// TestData.h file.
+/// Provides the fake MSAL objects used by the `FakeMSALPublicClientApplication`
+/// in MQQAAutomationApp,  and these fake objects are deserialized from strings
+/// declared in TestData.h.
 @interface FakeDataProvider : NSObject
+
++ (NSDictionary *)getDictFromString:(NSString *)str;
 
 + (MSALResult *)getFakeMSALResult;
 

--- a/iOS/MSQAAutomationApp/FakeDataProvider.m
+++ b/iOS/MSQAAutomationApp/FakeDataProvider.m
@@ -53,26 +53,6 @@
 
 @end
 
-@interface MSALResult (Testing)
-
-+ (MSALResult *)resultWithAccessToken:(NSString *)accessToken
-                            expiresOn:(NSDate *)expiresOn
-              isExtendedLifetimeToken:(BOOL)isExtendedLifetimeToken
-                             tenantId:(NSString *)tenantId
-                        tenantProfile:(MSALTenantProfile *)tenantProfile
-                              account:(MSALAccount *)account
-                              idToken:(NSString *)idToken
-                             uniqueId:(NSString *)uniqueId
-                               scopes:(NSArray<NSString *> *)scopes
-                            authority:(MSALAuthority *)authority
-                        correlationId:(NSUUID *)correlationId
-                           authScheme:
-                               (id<MSALAuthenticationSchemeProtocol,
-                                   MSALAuthenticationSchemeProtocolInternal>)
-                                   authScheme;
-
-@end
-
 @implementation FakeDataProvider
 
 + (NSDictionary *)getDictFromString:(NSString *)str {
@@ -104,7 +84,10 @@
 }
 
 + (MSALResult *)getFakeMSALResult {
-  return [[FakeMSALResult alloc] initWithString:kFakeMSALResult];
+  FakeMSALResult *result = [[FakeMSALResult alloc]
+      initWithString:kFakeMSALResult
+             account:[FakeDataProvider getFakeMSALAccount]];
+  return result;
 }
 
 @end

--- a/iOS/MSQAAutomationApp/FakeDataProvider.m
+++ b/iOS/MSQAAutomationApp/FakeDataProvider.m
@@ -71,6 +71,13 @@
 }
 
 + (MSALAccount *)getFakeMSALAccount {
+  BOOL canConstructMSALAccount = [MSALAccount
+      instanceMethodForSelector:@selector
+      (initWithUsername:homeAccountId:environment:tenantProfiles:)];
+
+  if (!canConstructMSALAccount) {
+    return nil;
+  }
   NSString *str =
       [NSString stringWithFormat:kFakeMSALAccount, kFakeHomeAccountId];
   NSDictionary *accountDict = [FakeDataProvider getDictFromString:str];
@@ -84,9 +91,13 @@
 }
 
 + (MSALResult *)getFakeMSALResult {
-  FakeMSALResult *result = [[FakeMSALResult alloc]
-      initWithString:kFakeMSALResult
-             account:[FakeDataProvider getFakeMSALAccount]];
+  MSALAccount *account = [FakeDataProvider getFakeMSALAccount];
+  if (!account) {
+    return nil;
+  }
+
+  FakeMSALResult *result =
+      [[FakeMSALResult alloc] initWithString:kFakeMSALResult account:account];
   return result;
 }
 

--- a/iOS/MSQAAutomationApp/FakeMSALPublicClientApplication.m
+++ b/iOS/MSQAAutomationApp/FakeMSALPublicClientApplication.m
@@ -59,13 +59,32 @@
 
 - (BOOL)removeAccount:(MSALAccount *)account
                 error:(NSError *_Nullable __autoreleasing *)error {
-  // TODO(minggang): Implement the mocked functionality.
-  return YES;
+  if (_hasSignedIn) {
+    _hasSignedIn = NO;
+    return YES;
+  }
+  NSError __autoreleasing *localError = [NSError errorWithDomain:@"NotSignIn"
+                                                            code:0
+                                                        userInfo:nil];
+  error = &localError;
+  return NO;
 }
 
 - (void)acquireTokenWithParameters:(MSALInteractiveTokenParameters *)parameters
                    completionBlock:(MSALCompletionBlock)completionBlock {
-  // TODO(minggang): Implement the mocked functionality.
+  if (!_willCancel) {
+    dispatch_async(parameters.completionBlockQueue, ^{
+      completionBlock([FakeDataProvider getFakeMSALResult], nil);
+    });
+    return;
+  }
+  NSError *error =
+      [NSError errorWithDomain:MSALErrorDomain
+                          code:-42400
+                      userInfo:@{MSALOAuthErrorKey : @"access_denied"}];
+  dispatch_async(parameters.completionBlockQueue, ^{
+    completionBlock(nil, error);
+  });
 }
 
 - (void)acquireTokenSilentWithParameters:(MSALSilentTokenParameters *)parameters

--- a/iOS/MSQAAutomationApp/FakeMSALResult.h
+++ b/iOS/MSQAAutomationApp/FakeMSALResult.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FakeMSALResult : MSALResult
 
-- (instancetype)initWithString:(NSString *)str;
+- (instancetype)initWithString:(NSString *)str account:(MSALAccount *)account;
 
 @end
 

--- a/iOS/MSQAAutomationApp/FakeMSALResult.m
+++ b/iOS/MSQAAutomationApp/FakeMSALResult.m
@@ -41,9 +41,10 @@
 
 @implementation FakeMSALResult {
   NSDictionary *_tokenResultDict;
+  MSALAccount *_msalAccount;
 }
 
-- (instancetype)initWithString:(NSString *)str {
+- (instancetype)initWithString:(NSString *)str account:(MSALAccount *)account {
   if (!(self = [super init])) {
     return nil;
   }
@@ -51,6 +52,8 @@
   _tokenResultDict = [NSJSONSerialization JSONObjectWithData:data
                                                      options:0
                                                        error:nil];
+  _msalAccount = account;
+
   return self;
 }
 
@@ -88,6 +91,14 @@
 - (NSUUID *)correlationId {
   return [[NSUUID alloc]
       initWithUUIDString:[_tokenResultDict valueForKey:@"correlationId"]];
+}
+
+- (NSString *)idToken {
+  return [_tokenResultDict valueForKey:@"idToken"];
+}
+
+- (MSALAccount *)account {
+  return _msalAccount;
 }
 
 @end

--- a/iOS/MSQAAutomationApp/FakeMSQAUserInfoFetcher.h
+++ b/iOS/MSQAAutomationApp/FakeMSQAUserInfoFetcher.h
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -23,15 +25,16 @@
 //
 //------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
+#import <MSQASignIn/MSQAUserInfoFetcher.h>
 
-// This group of strings can be deserialized into the MSAL classes,
-// `MSALAccountId`, `MSALAccount` and `MSALResult`, by `FakeDataProvider`, which
-// serves the `FakeMSALPublicClientApplication` in the MSQAAutomationApp.
-extern NSString *const kFakeHomeAccountId;
-extern NSString *const kFakeMSALAccount;
-extern NSString *const kFakeMSALResult;
+NS_ASSUME_NONNULL_BEGIN
 
-// The serialized string that represents the expected `MSQAAccountInfo` object
-// in the automation tests.
-extern NSString *const kExpectedMSQAAccount;
+@interface FakeMSQAUserInfoFetcher : MSQAUserInfoFetcher
+
++ (instancetype)fetchUserInfoWithAccount:(MSQAAccountInfo *)account
+                         completionBlock:
+                             (UserInfoFetcherCompletionBlock)completionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/MSQAAutomationApp/FakeMSQAUserInfoFetcher.m
+++ b/iOS/MSQAAutomationApp/FakeMSQAUserInfoFetcher.m
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -23,15 +25,31 @@
 //
 //------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
+#import "FakeMSQAUserInfoFetcher.h"
 
-// This group of strings can be deserialized into the MSAL classes,
-// `MSALAccountId`, `MSALAccount` and `MSALResult`, by `FakeDataProvider`, which
-// serves the `FakeMSALPublicClientApplication` in the MSQAAutomationApp.
-extern NSString *const kFakeHomeAccountId;
-extern NSString *const kFakeMSALAccount;
-extern NSString *const kFakeMSALResult;
+#import "FakeDataProvider.h"
+#import "MSQAAccountInfo_Private.h"
+#import "TestData.h"
 
-// The serialized string that represents the expected `MSQAAccountInfo` object
-// in the automation tests.
-extern NSString *const kExpectedMSQAAccount;
+@implementation FakeMSQAUserInfoFetcher
+
++ (instancetype)fetchUserInfoWithAccount:(MSQAAccountInfo *)account
+                         completionBlock:
+                             (UserInfoFetcherCompletionBlock)completionBlock {
+  NSDictionary *dict =
+      [FakeDataProvider getDictFromString:kExpectedMSQAAccount];
+
+  if (dict) {
+    account.surname = dict[@"surname"];
+    account.givenName = dict[@"givenName"];
+    account.email = dict[@"email"];
+    account.base64Photo = dict[@"photo"];
+  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionBlock(nil);
+  });
+
+  return [[FakeMSQAUserInfoFetcher alloc] init];
+}
+
+@end

--- a/iOS/MSQAAutomationApp/MSQAAccountInfo+Testing.h
+++ b/iOS/MSQAAutomationApp/MSQAAccountInfo+Testing.h
@@ -55,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setEmail:(NSString *)email;
 
+- (void)setBase64Photo:(NSString *)base64Photo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iOS/MSQAAutomationApp/MSQAAccountInfo+Testing.m
+++ b/iOS/MSQAAutomationApp/MSQAAccountInfo+Testing.m
@@ -37,7 +37,8 @@
     @"idToken" : self.idToken,
     @"surname" : self.surname,
     @"givenName" : self.givenName,
-    @"email" : self.email
+    @"email" : self.email,
+    @"photo" : self.base64Photo
   };
   NSData *resultData = [NSJSONSerialization dataWithJSONObject:dict
                                                        options:0
@@ -57,9 +58,12 @@
                                          userId:dict[@"userId"]
                                         idToken:dict[@"idToken"]
                                     accessToken:nil];
+
   [account setSurname:dict[@"surname"]];
   [account setGivenName:dict[@"givenName"]];
   [account setEmail:dict[@"email"]];
+  [account setBase64Photo:dict[@"photo"]];
+
   return account;
 }
 
@@ -70,7 +74,8 @@
          [self.idToken isEqualToString:account.idToken] &&
          [self.surname isEqualToString:account.surname] &&
          [self.givenName isEqualToString:account.givenName] &&
-         [self.email isEqualToString:account.email];
+         [self.email isEqualToString:account.email] &&
+         [self.base64Photo isEqualToString:account.base64Photo];
 }
 
 @end

--- a/iOS/MSQAAutomationApp/TestData.m
+++ b/iOS/MSQAAutomationApp/TestData.m
@@ -39,7 +39,10 @@ NSString *const kFakeMSALAccount =
 NSString *const kExpectedMSQAAccount =
     @"{\"fullName\":\"FirstName LastName\", \"userName\": "
     @"\"user@hotmail.com\", "
-    @"\"userId\":\"111bb81e2ee60a77\",\"idToken\":\"id_token\"}";
+    @"\"userId\":\"111bb81e2ee60a77\", \"surname\":\"surname\", "
+    @"\"givenName\":\"givenName\", "
+    @"\"email\":\"user@hotmail.com\", \"idToken\":\"id_token\", "
+    @"\"photo\":\"user_photo\"}";
 
 NSString *const kFakeMSALResult =
     @"{\"accessToken\":\"accesst_token\", "
@@ -48,6 +51,4 @@ NSString *const kFakeMSALResult =
     @"\"expiresOn\": \"2025-01-01\", "
     @"\"tenantId\":\"tenant_id\", "
     @"\"scopes\":[\"User.Read\"],\"correlationId\": "
-    @"\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\"}";
-
-NSString *const kNoCachedAccount = @"no-cached-account";
+    @"\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\", \"idToken\":\"id_token\"}";

--- a/iOS/MSQAAutomationApp/ViewController.m
+++ b/iOS/MSQAAutomationApp/ViewController.m
@@ -27,11 +27,14 @@
 
 #import "ViewController.h"
 
-#import <MSQASignIn/MSQASignInClient.h>
+#import <MSQASignIn/MSQASignInButton.h>
+#import <MSQASignIn/MSQASignIn_Private.h>
 #import <MSQASignIn/MSQASilentTokenParameters.h>
 
 #import "AppDelegate.h"
 #import "FakeMSALPublicClientApplication.h"
+#import "FakeMSQAUserInfoFetcher.h"
+#import "MSQAAccountInfo+Testing.h"
 #import "MSQATokenResult+Testing.h"
 #import "TestData.h"
 
@@ -45,13 +48,17 @@
 
 @property(nonatomic) FakeMSALPublicClientApplication *application;
 
-@property(nonatomic) MSQASignInClient *msSignIn;
+@property(nonatomic) MSQASignInClient *msSignInClient;
+
+@property(strong, nonatomic) IBOutlet MSQASignInButton *msSignInButtonAccepted;
+
+@property(strong, nonatomic) IBOutlet MSQASignInButton *msSignInButtonCanceled;
 
 @end
 
 @implementation ViewController {
   FakeMSALPublicClientApplication *_application;
-  MSQASignInClient *_msSignIn;
+  MSQASignInClient *_msSignInClient;
 }
 
 - (void)viewDidLoad {
@@ -61,35 +68,170 @@
       (AppDelegate *)[[UIApplication sharedApplication] delegate];
 
   _application = delegate.application;
-  _msSignIn = delegate.msSignIn;
+  _msSignInClient = delegate.msSignInClient;
+  [_msSignInClient
+      setMSQAUserInfoFetcherForTesting:[FakeMSQAUserInfoFetcher class]];
+
+  [_msSignInButtonAccepted setSignInClient:_msSignInClient
+                            viewController:self
+                           completionBlock:^(MSQAAccountInfo *_Nullable account,
+                                             NSError *_Nullable error) {
+                             if (!error) {
+                               self->_resultInfo.text = [account toJSONString];
+                             }
+                             self->_resultStatus.text = @"done";
+                           }];
+
+  [_msSignInButtonCanceled setSignInClient:_msSignInClient
+                            viewController:self
+                           completionBlock:^(MSQAAccountInfo *_Nullable account,
+                                             NSError *_Nullable error) {
+                             if (error) {
+                               self->_resultInfo.text =
+                                   error.userInfo[MSALOAuthErrorKey];
+                             }
+                             self->_resultStatus.text = @"done";
+                           }];
+}
+
+- (void)willSignIn:(MSQASignInButton *)msSignInButton {
+  if ([msSignInButton.accessibilityIdentifier
+          isEqualToString:@"ms button sign in with accept"]) {
+    _application.willCancel = NO;
+  }
+  if ([msSignInButton.accessibilityIdentifier
+          isEqualToString:@"ms button sign in with cancel"]) {
+    _application.willCancel = YES;
+  }
 }
 
 - (IBAction)fetchTokenSilentBeforeSignIn:(id)sender {
   _application.hasSignedIn = NO;
   MSQASilentTokenParameters *parameters =
       [[MSQASilentTokenParameters alloc] initWithScopes:@[ @"User.Read" ]];
-  [_msSignIn acquireTokenSilentWithParameters:parameters
-                              completionBlock:^(MSQATokenResult *token,
-                                                NSError *error) {
-                                self->_resultStatus.text = @"done";
-                                if (!token && !error) {
-                                  self->_resultInfo.text = kNoCachedAccount;
-                                }
-                              }];
+  [_msSignInClient acquireTokenSilentWithParameters:parameters
+                                    completionBlock:^(MSQATokenResult *token,
+                                                      NSError *error) {
+                                      self->_resultStatus.text = @"done";
+                                      if (!token && !error) {
+                                        self->_resultInfo.text =
+                                            @"no-cached-account";
+                                      }
+                                    }];
 }
 
 - (IBAction)fetchTokenSilentAfterSignIn:(id)sender {
   _application.hasSignedIn = YES;
   MSQASilentTokenParameters *parameters =
       [[MSQASilentTokenParameters alloc] initWithScopes:@[ @"User.Read" ]];
-  [_msSignIn acquireTokenSilentWithParameters:parameters
-                              completionBlock:^(MSQATokenResult *token,
-                                                NSError *error) {
-                                if (token && !error) {
-                                  self->_resultInfo.text = [token toJSONString];
-                                }
-                                self->_resultStatus.text = @"done";
-                              }];
+  [_msSignInClient acquireTokenSilentWithParameters:parameters
+                                    completionBlock:^(MSQATokenResult *token,
+                                                      NSError *error) {
+                                      if (token && !error) {
+                                        self->_resultInfo.text =
+                                            [token toJSONString];
+                                      }
+                                      self->_resultStatus.text = @"done";
+                                    }];
+}
+
+- (IBAction)fetchTokenInteractiveWithPromptAccepted:(id)sender {
+  _application.willCancel = NO;
+  MSQAWebviewParameters *webParameters = [[MSQAWebviewParameters alloc]
+      initWithAuthPresentationViewController:self];
+  MSQAInteractiveTokenParameters *parameters =
+      [[MSALInteractiveTokenParameters alloc]
+             initWithScopes:@[ @"User.Read", @"Calendars.Read" ]
+          webviewParameters:webParameters];
+
+  [_msSignInClient
+      acquireTokenWithParameters:parameters
+                 completionBlock:^(MSQATokenResult *_Nullable token,
+                                   NSError *_Nullable error) {
+                   if (token && !error) {
+                     self->_resultInfo.text = [token toJSONString];
+                   }
+                   self->_resultStatus.text = @"done";
+                 }];
+}
+
+- (IBAction)fetchTokenInteractiveWithPromptCanceled:(id)sender {
+  _application.willCancel = YES;
+  MSQAWebviewParameters *webParameters = [[MSQAWebviewParameters alloc]
+      initWithAuthPresentationViewController:self];
+  MSQAInteractiveTokenParameters *parameters =
+      [[MSALInteractiveTokenParameters alloc]
+             initWithScopes:@[ @"User.Read", @"Calendars.Read" ]
+          webviewParameters:webParameters];
+
+  [_msSignInClient
+      acquireTokenWithParameters:parameters
+                 completionBlock:^(MSQATokenResult *_Nullable token,
+                                   NSError *_Nullable error) {
+                   if (error) {
+                     self->_resultInfo.text = error.userInfo[MSALOAuthErrorKey];
+                   }
+                   self->_resultStatus.text = @"done";
+                 }];
+}
+
+- (IBAction)getCurrentAccountAfterSignIn:(id)sender {
+  _application.hasSignedIn = YES;
+  [_msSignInClient
+      getCurrentAccountWithCompletionBlock:^(MSQAAccountInfo *_Nullable account,
+                                             NSError *_Nullable error) {
+        if (account && !error) {
+          self->_resultInfo.text = [account toJSONString];
+        }
+        self->_resultStatus.text = @"done";
+      }];
+}
+
+- (IBAction)getCurrentAccountBeforeSignIn:(id)sender {
+  _application.hasSignedIn = NO;
+  [_msSignInClient
+      getCurrentAccountWithCompletionBlock:^(MSQAAccountInfo *_Nullable account,
+                                             NSError *_Nullable error) {
+        if (!account && !error) {
+          self->_resultInfo.text = @"No account presents";
+        }
+        self->_resultStatus.text = @"done";
+      }];
+}
+
+- (IBAction)signOut:(id)sender {
+  _application.hasSignedIn = YES;
+  [_msSignInClient signOutWithCompletionBlock:^(NSError *_Nullable error) {
+    if (!error) {
+      self->_resultInfo.text = @"success";
+    }
+    self->_resultStatus.text = @"done";
+  }];
+}
+
+- (IBAction)signInWithPromptAccepted:(id)sender {
+  _application.willCancel = NO;
+  [_msSignInClient signInWithViewController:self
+                            completionBlock:^(MSQAAccountInfo *_Nonnull account,
+                                              NSError *_Nonnull error) {
+                              if (!error) {
+                                self->_resultInfo.text = [account toJSONString];
+                              }
+                              self->_resultStatus.text = @"done";
+                            }];
+}
+
+- (IBAction)signInWithPromptCanceled:(id)sender {
+  _application.willCancel = YES;
+  [_msSignInClient signInWithViewController:self
+                            completionBlock:^(MSQAAccountInfo *_Nonnull account,
+                                              NSError *_Nonnull error) {
+                              if (error) {
+                                self->_resultInfo.text =
+                                    error.userInfo[MSALOAuthErrorKey];
+                              }
+                              self->_resultStatus.text = @"done";
+                            }];
 }
 
 @end

--- a/iOS/MSQAAutomationAppUITests/AcquireTokenInteractiveTest.m
+++ b/iOS/MSQAAutomationAppUITests/AcquireTokenInteractiveTest.m
@@ -27,33 +27,20 @@
 
 #import "MSQABaseUITest.h"
 
+#import "MSQAAccountInfo+Testing.h"
 #import "MSQATokenResult+Testing.h"
 #import "TestData.h"
 
-@interface AcquireTokenSilentTest : MSQABaseUITest
+@interface AcquireTokenInteractiveTest : MSQABaseUITest
 
 @end
 
-@implementation AcquireTokenSilentTest
+@implementation AcquireTokenInteractiveTest
 
-- (void)testAcquireTokenSilent_beforeSignIn {
+- (void)testAcquireTokenInteractivelyTest_withAccept {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-
-  XCUIElement *button = app.buttons[@"fetch token silent before signin"];
-  [self waitForElement:button];
-  [button tap];
-
-  XCUIElement *resultStatus = app.textViews[@"Result Status"];
-  [self waitForResultStatus:resultStatus];
-  XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  XCTAssertTrue([resultInfo.value isEqualToString:@"no-cached-account"]);
-}
-
-- (void)testAcquireTokenSilent_afterSignIn {
-  XCUIApplication *app = [[XCUIApplication alloc] init];
-  [app launch];
-  XCUIElement *button = app.buttons[@"fetch token silent after signin"];
+  XCUIElement *button = app.buttons[@"fetch token interactive"];
   [self waitForElement:button];
   [button tap];
 
@@ -64,6 +51,20 @@
   MSQATokenResult *expected = [MSQATokenResult fromJSONString:kFakeMSALResult];
   MSQATokenResult *actual = [MSQATokenResult fromJSONString:resultInfo.value];
   XCTAssertTrue([actual isEqual:expected]);
+}
+
+- (void)testAcquireTokenInteractivelyTest_withCancel {
+  XCUIApplication *app = [[XCUIApplication alloc] init];
+  [app launch];
+  XCUIElement *button = app.buttons[@"fetch token interactive with cancel"];
+  [self waitForElement:button];
+  [button tap];
+
+  XCUIElement *resultStatus = app.textViews[@"Result Status"];
+  [self waitForResultStatus:resultStatus];
+
+  XCUIElement *resultInfo = app.textViews[@"Result Info"];
+  XCTAssertTrue([resultInfo.value isEqual:@"access_denied"]);
 }
 
 @end

--- a/iOS/MSQAAutomationAppUITests/GetCurrentAccountTest.m
+++ b/iOS/MSQAAutomationAppUITests/GetCurrentAccountTest.m
@@ -27,43 +27,44 @@
 
 #import "MSQABaseUITest.h"
 
-#import "MSQATokenResult+Testing.h"
+#import "MSQAAccountInfo+Testing.h"
 #import "TestData.h"
 
-@interface AcquireTokenSilentTest : MSQABaseUITest
+@interface GetCurrentAccountTest : MSQABaseUITest
 
 @end
 
-@implementation AcquireTokenSilentTest
+@implementation GetCurrentAccountTest
 
-- (void)testAcquireTokenSilent_beforeSignIn {
+- (void)testGetCurrentAccount_beforeSignIn {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
 
-  XCUIElement *button = app.buttons[@"fetch token silent before signin"];
+  XCUIElement *button = app.buttons[@"get current account before signin"];
   [self waitForElement:button];
   [button tap];
 
   XCUIElement *resultStatus = app.textViews[@"Result Status"];
   [self waitForResultStatus:resultStatus];
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  XCTAssertTrue([resultInfo.value isEqualToString:@"no-cached-account"]);
+  XCTAssertTrue([resultInfo.value isEqualToString:@"No account presents"]);
 }
 
-- (void)testAcquireTokenSilent_afterSignIn {
+- (void)testGetCurrentAccount_afterSignIn {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-  XCUIElement *button = app.buttons[@"fetch token silent after signin"];
+
+  XCUIElement *button = app.buttons[@"get current account after signin"];
   [self waitForElement:button];
   [button tap];
 
   XCUIElement *resultStatus = app.textViews[@"Result Status"];
   [self waitForResultStatus:resultStatus];
-
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  MSQATokenResult *expected = [MSQATokenResult fromJSONString:kFakeMSALResult];
-  MSQATokenResult *actual = [MSQATokenResult fromJSONString:resultInfo.value];
-  XCTAssertTrue([actual isEqual:expected]);
+  MSQAAccountInfo *expected =
+      [MSQAAccountInfo fromJSONString:kExpectedMSQAAccount];
+  MSQAAccountInfo *actual = [MSQAAccountInfo fromJSONString:resultInfo.value];
+  XCTAssertTrue([expected isEqual:actual]);
 }
 
 @end

--- a/iOS/MSQAAutomationAppUITests/MSQASignInButtonTest.m
+++ b/iOS/MSQAAutomationAppUITests/MSQASignInButtonTest.m
@@ -27,33 +27,33 @@
 
 #import "MSQABaseUITest.h"
 
-#import "MSQATokenResult+Testing.h"
+#import "MSQAAccountInfo+Testing.h"
 #import "TestData.h"
 
-@interface AcquireTokenSilentTest : MSQABaseUITest
+@interface MSQASignInButtonTest : MSQABaseUITest
 
 @end
 
-@implementation AcquireTokenSilentTest
+@implementation MSQASignInButtonTest
 
-- (void)testAcquireTokenSilent_beforeSignIn {
+- (void)testMSSignInButton_withPromptCanceled {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-
-  XCUIElement *button = app.buttons[@"fetch token silent before signin"];
+  XCUIElement *button = app.otherElements[@"ms button sign in with cancel"];
   [self waitForElement:button];
   [button tap];
 
   XCUIElement *resultStatus = app.textViews[@"Result Status"];
   [self waitForResultStatus:resultStatus];
+
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  XCTAssertTrue([resultInfo.value isEqualToString:@"no-cached-account"]);
+  XCTAssertTrue([resultInfo.value isEqual:@"access_denied"]);
 }
 
-- (void)testAcquireTokenSilent_afterSignIn {
+- (void)testMSSignInButton_withPromptAccepted {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-  XCUIElement *button = app.buttons[@"fetch token silent after signin"];
+  XCUIElement *button = app.otherElements[@"ms button sign in with accept"];
   [self waitForElement:button];
   [button tap];
 
@@ -61,8 +61,9 @@
   [self waitForResultStatus:resultStatus];
 
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  MSQATokenResult *expected = [MSQATokenResult fromJSONString:kFakeMSALResult];
-  MSQATokenResult *actual = [MSQATokenResult fromJSONString:resultInfo.value];
+  MSQAAccountInfo *actual = [MSQAAccountInfo fromJSONString:resultInfo.value];
+  MSQAAccountInfo *expected =
+      [MSQAAccountInfo fromJSONString:kExpectedMSQAAccount];
   XCTAssertTrue([actual isEqual:expected]);
 }
 

--- a/iOS/MSQAAutomationAppUITests/SignInByAPITest.m
+++ b/iOS/MSQAAutomationAppUITests/SignInByAPITest.m
@@ -27,33 +27,33 @@
 
 #import "MSQABaseUITest.h"
 
-#import "MSQATokenResult+Testing.h"
+#import "MSQAAccountInfo+Testing.h"
 #import "TestData.h"
 
-@interface AcquireTokenSilentTest : MSQABaseUITest
+@interface SignInByAPITest : MSQABaseUITest
 
 @end
 
-@implementation AcquireTokenSilentTest
+@implementation SignInByAPITest
 
-- (void)testAcquireTokenSilent_beforeSignIn {
+- (void)testSignIn_withPromptCanceled {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-
-  XCUIElement *button = app.buttons[@"fetch token silent before signin"];
+  XCUIElement *button = app.buttons[@"sign in with cancel"];
   [self waitForElement:button];
   [button tap];
 
   XCUIElement *resultStatus = app.textViews[@"Result Status"];
   [self waitForResultStatus:resultStatus];
+
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  XCTAssertTrue([resultInfo.value isEqualToString:@"no-cached-account"]);
+  XCTAssertTrue([resultInfo.value isEqual:@"access_denied"]);
 }
 
-- (void)testAcquireTokenSilent_afterSignIn {
+- (void)testSignIn_withPromptAccepted {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
-  XCUIElement *button = app.buttons[@"fetch token silent after signin"];
+  XCUIElement *button = app.buttons[@"sign in with accept"];
   [self waitForElement:button];
   [button tap];
 
@@ -61,8 +61,9 @@
   [self waitForResultStatus:resultStatus];
 
   XCUIElement *resultInfo = app.textViews[@"Result Info"];
-  MSQATokenResult *expected = [MSQATokenResult fromJSONString:kFakeMSALResult];
-  MSQATokenResult *actual = [MSQATokenResult fromJSONString:resultInfo.value];
+  MSQAAccountInfo *actual = [MSQAAccountInfo fromJSONString:resultInfo.value];
+  MSQAAccountInfo *expected =
+      [MSQAAccountInfo fromJSONString:kExpectedMSQAAccount];
   XCTAssertTrue([actual isEqual:expected]);
 }
 

--- a/iOS/MSQAAutomationAppUITests/SignOutByAPITest.m
+++ b/iOS/MSQAAutomationAppUITests/SignOutByAPITest.m
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -23,15 +25,26 @@
 //
 //------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
+#import "MSQABaseUITest.h"
 
-// This group of strings can be deserialized into the MSAL classes,
-// `MSALAccountId`, `MSALAccount` and `MSALResult`, by `FakeDataProvider`, which
-// serves the `FakeMSALPublicClientApplication` in the MSQAAutomationApp.
-extern NSString *const kFakeHomeAccountId;
-extern NSString *const kFakeMSALAccount;
-extern NSString *const kFakeMSALResult;
+@interface SignOutByAPITest : MSQABaseUITest
 
-// The serialized string that represents the expected `MSQAAccountInfo` object
-// in the automation tests.
-extern NSString *const kExpectedMSQAAccount;
+@end
+
+@implementation SignOutByAPITest
+
+- (void)testSignOut {
+  XCUIApplication *app = [[XCUIApplication alloc] init];
+  [app launch];
+
+  XCUIElement *button = app.buttons[@"sign out"];
+  [self waitForElement:button];
+  [button tap];
+
+  XCUIElement *resultStatus = app.textViews[@"Result Status"];
+  [self waitForResultStatus:resultStatus];
+  XCUIElement *resultInfo = app.textViews[@"Result Info"];
+  XCTAssertTrue([resultInfo.value isEqualToString:@"success"]);
+}
+
+@end

--- a/iOS/MSQASignIn.xcodeproj/project.pbxproj
+++ b/iOS/MSQASignIn.xcodeproj/project.pbxproj
@@ -29,6 +29,12 @@
 		2998FE5A290A51E600CF957D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2998FE5C290A51E600CF957D /* Localizable.strings */; };
 		29BCDAF128D45CF100AC4047 /* Pods_MSQASignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29BCDAF028D45CF100AC4047 /* Pods_MSQASignIn.framework */; };
 		29BCDAF728DB0F5300AC4047 /* MSQATelemetrySender.m in Sources */ = {isa = PBXBuildFile; fileRef = 29BCDAF528DB0F5300AC4047 /* MSQATelemetrySender.m */; };
+		29D75AFC28FE4C0F00ADCDED /* AcquireTokenInteractiveTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75AFB28FE4C0F00ADCDED /* AcquireTokenInteractiveTest.m */; };
+		29D75AFE28FE709300ADCDED /* GetCurrentAccountTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75AFD28FE709300ADCDED /* GetCurrentAccountTest.m */; };
+		29D75B0128FE871900ADCDED /* FakeMSQAUserInfoFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75B0028FE871900ADCDED /* FakeMSQAUserInfoFetcher.m */; };
+		29D75B0328FFD5E100ADCDED /* SignOutByAPITest.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75B0228FFD5E100ADCDED /* SignOutByAPITest.m */; };
+		29D75B0528FFE6DF00ADCDED /* SignInByAPITest.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75B0428FFE6DF00ADCDED /* SignInByAPITest.m */; };
+		29D75B0A2902792400ADCDED /* MSQASignInButtonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 29D75B092902792400ADCDED /* MSQASignInButtonTest.m */; };
 		29E06DD828B8C6B1003D558A /* MSQASignIn_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29DC397028A6551300699274 /* MSQASignIn_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		29E06DD928B8C6B1003D558A /* MSQASignInButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 292FB4D528B755D000E846A5 /* MSQASignInButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E06DDA28B8C6B1003D558A /* MSQASignInClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 29DC394428A63F6E00699274 /* MSQASignInClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -142,6 +148,13 @@
 		29BCDAF028D45CF100AC4047 /* Pods_MSQASignIn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_MSQASignIn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		29BCDAF428DB0F5300AC4047 /* MSQATelemetrySender.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQATelemetrySender.h; sourceTree = "<group>"; };
 		29BCDAF528DB0F5300AC4047 /* MSQATelemetrySender.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSQATelemetrySender.m; sourceTree = "<group>"; };
+		29D75AFB28FE4C0F00ADCDED /* AcquireTokenInteractiveTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AcquireTokenInteractiveTest.m; sourceTree = "<group>"; };
+		29D75AFD28FE709300ADCDED /* GetCurrentAccountTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GetCurrentAccountTest.m; sourceTree = "<group>"; };
+		29D75AFF28FE871900ADCDED /* FakeMSQAUserInfoFetcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FakeMSQAUserInfoFetcher.h; sourceTree = "<group>"; };
+		29D75B0028FE871900ADCDED /* FakeMSQAUserInfoFetcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FakeMSQAUserInfoFetcher.m; sourceTree = "<group>"; };
+		29D75B0228FFD5E100ADCDED /* SignOutByAPITest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SignOutByAPITest.m; sourceTree = "<group>"; };
+		29D75B0428FFE6DF00ADCDED /* SignInByAPITest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SignInByAPITest.m; sourceTree = "<group>"; };
+		29D75B092902792400ADCDED /* MSQASignInButtonTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSQASignInButtonTest.m; sourceTree = "<group>"; };
 		29DC394428A63F6E00699274 /* MSQASignInClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQASignInClient.h; sourceTree = "<group>"; };
 		29DC394528A63F6E00699274 /* MSQASignIn.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = MSQASignIn.docc; sourceTree = "<group>"; };
 		29DC394B28A63F6E00699274 /* MSQASignInTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MSQASignInTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -399,6 +412,8 @@
 				2903637728F56A6300142C95 /* MSQASignIn+Testing.m */,
 				29FDDB0028FD6181003A5EA8 /* FakeMSALResult.h */,
 				29FDDB0128FD6181003A5EA8 /* FakeMSALResult.m */,
+				29D75AFF28FE871900ADCDED /* FakeMSQAUserInfoFetcher.h */,
+				29D75B0028FE871900ADCDED /* FakeMSQAUserInfoFetcher.m */,
 			);
 			path = MSQAAutomationApp;
 			sourceTree = "<group>";
@@ -406,6 +421,11 @@
 		B30C49E028F00C0000A4E770 /* MSQAAutomationAppUITests */ = {
 			isa = PBXGroup;
 			children = (
+				29D75B092902792400ADCDED /* MSQASignInButtonTest.m */,
+				29D75B0428FFE6DF00ADCDED /* SignInByAPITest.m */,
+				29D75B0228FFD5E100ADCDED /* SignOutByAPITest.m */,
+				29D75AFD28FE709300ADCDED /* GetCurrentAccountTest.m */,
+				29D75AFB28FE4C0F00ADCDED /* AcquireTokenInteractiveTest.m */,
 				B30C49E128F00C0000A4E770 /* AcquireTokenSilentTest.m */,
 				B30C49EF28F282F600A4E770 /* MSQABaseUITest.h */,
 				B30C49F028F282F600A4E770 /* MSQABaseUITest.m */,
@@ -758,6 +778,7 @@
 				B30C49C128EF348300A4E770 /* AppDelegate.m in Sources */,
 				B30C49D228EF348600A4E770 /* main.m in Sources */,
 				29FDDB0228FD6181003A5EA8 /* FakeMSALResult.m in Sources */,
+				29D75B0128FE871900ADCDED /* FakeMSQAUserInfoFetcher.m in Sources */,
 				B30C49FE28F43E9600A4E770 /* MSQAAccountInfo+Testing.m in Sources */,
 				B30C49F428F3CE4700A4E770 /* FakeDataProvider.m in Sources */,
 			);
@@ -768,10 +789,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				29FDDB0428FD74B1003A5EA8 /* MSQATokenResult+Testing.m in Sources */,
+				29D75AFC28FE4C0F00ADCDED /* AcquireTokenInteractiveTest.m in Sources */,
+				29D75B0A2902792400ADCDED /* MSQASignInButtonTest.m in Sources */,
 				29FDDB0328FD7476003A5EA8 /* MSQATokenResult+Testing.h in Sources */,
+				29D75B0528FFE6DF00ADCDED /* SignInByAPITest.m in Sources */,
 				B30C49E228F00C0000A4E770 /* AcquireTokenSilentTest.m in Sources */,
 				B30C49FF28F43E9600A4E770 /* MSQAAccountInfo+Testing.m in Sources */,
 				B30C49FB28F42BE000A4E770 /* TestData.m in Sources */,
+				29D75B0328FFD5E100ADCDED /* SignOutByAPITest.m in Sources */,
+				29D75AFE28FE709300ADCDED /* GetCurrentAccountTest.m in Sources */,
 				B30C49F128F282F600A4E770 /* MSQABaseUITest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/MSQASignIn/src/MSQASignInButton.m
+++ b/iOS/MSQASignIn/src/MSQASignInButton.m
@@ -418,6 +418,13 @@ typedef NS_ENUM(NSUInteger, MSQASignInButtonState) {
 }
 
 - (void)onButtonClicked {
+  // Performing selector `willSignIn:` is needed by the automation test where we
+  // will set the MSAL status before starting to sign in.
+  if (_viewController &&
+      [_viewController respondsToSelector:@selector(willSignIn:)]) {
+    [_viewController performSelector:@selector(willSignIn:) withObject:self];
+  }
+
   if (_msSignInClient) {
     [_msSignInClient signInByButtonWithViewController:_viewController
                                       completionBlock:_completionBlock];

--- a/iOS/MSQASignIn/src/MSQASignIn_Private.h
+++ b/iOS/MSQASignIn/src/MSQASignIn_Private.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)signInInternalWithViewController:(UIViewController *)controller
                          completionBlock:(MSQACompletionBlock)completionBlock;
 
+- (void)setMSQAUserInfoFetcherForTesting:(Class)cls;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This patch adds the following cases into MSQAAutomationAppUITests target:

- AcquireTokenInteractiveTest
- AcquireTokenSilentTest
- GetCurrentAccountTest
- SignInByAPITest
- SignOutByAPITest
- MSQASignInButtonTest

Please check with the scenarios designed in [doc](https://microsoft.sharepoint.com/teams/Edge/_layouts/15/Doc.aspx?sourcedoc={60a6eb4b-96f8-45da-adcf-92e6d60d5584}&action=edit&wd=target%28Sign-in%20with%20MSA.one%7Ca6ca98aa-31e7-4b04-b714-76523caedb14%2FMicrosoft%20Quick%20Authentication%20mobile%20-%20Test%20scenarios%20%20automated%20tests%7C6de17261-6dda-488e-8f81-f9b699fc3825%2F%29&wdorigin=NavigationUrl).