### PR TITLE
[iOS][SampleApp] Update the SampleApp

### DIFF
--- a/iOS/SampleApp/SampleAppiOS/Info.plist
+++ b/iOS/SampleApp/SampleAppiOS/Info.plist
@@ -27,7 +27,7 @@
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>msauth.com.microsoft.signinDemo</string>
+				<string>msauth.com.microsoft.signinDemo-df</string>
 			</array>
 		</dict>
 	</array>

--- a/iOS/SampleApp/SampleAppiOS/SampleLoginViewController.m
+++ b/iOS/SampleApp/SampleAppiOS/SampleLoginViewController.m
@@ -229,7 +229,7 @@
   UIAlertController *alertController = [UIAlertController
       alertControllerWithTitle:title
                        message:nil
-                preferredStyle:UIAlertControllerStyleActionSheet];
+                preferredStyle:UIAlertControllerStyleAlert];
   [alertController setValue:viewController forKey:@"contentViewController"];
   [alertController
       addAction:[UIAlertAction actionWithTitle:@"Done"

--- a/iOS/SampleApp/SampleAppiOS/SampleMainViewController.m
+++ b/iOS/SampleApp/SampleAppiOS/SampleMainViewController.m
@@ -152,7 +152,7 @@
   UIAlertController *controller = [UIAlertController
       alertControllerWithTitle:@"Current account"
                        message:message
-                preferredStyle:UIAlertControllerStyleActionSheet];
+                preferredStyle:UIAlertControllerStyleAlert];
   UIAlertAction *action =
       [UIAlertAction actionWithTitle:@"OK"
                                style:UIAlertActionStyleDefault


### PR DESCRIPTION
This patch makes the following changes:

- Per dogFood bundleId change, change the application's redirect URL scheme in `Info.plist` to msauth.com.microsoft.signinDemo-df
- Change the `UIAlertControl` style to `UIAlertControllerStyleAlert` in order to adapt the iPadOS.