### PR TITLE
[iOS] Add SwiftUI support with sample app

### DIFF
--- a/MicrosoftQuickAuthSwiftSupport.podspec
+++ b/MicrosoftQuickAuthSwiftSupport.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name                  = 'MicrosoftQuickAuthSwiftSupport'
+  s.version               = '0.0.5'
+  s.summary               = 'Add Swift-UI support for MicrosoftQuickAuth.'
+  s.homepage              = 'https://github.com/microsoft/quick-authentication/blob/main/docs/quick-authentication-ios-how-to.md'
+  s.license               = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors               = { 'Microsoft' => 'minggangwang@microsoft.com' }
+  s.platform              = :ios
+  s.ios.deployment_target = '13.0'
+  s.source                = { :git => 'https://github.com/microsoft/quick-authentication-mobile.git', :tag => s.version.to_s }
+  s.module_name           = 'MSQASignInSwift'
+  s.prefix_header_file    = false
+  s.source_files          = 'iOS/MSQASignInSwift/*.swift'
+  s.frameworks            = 'SwiftUI'
+  s.dependency 'MicrosoftQuickAuth', '~> 0.0.5'
+end

--- a/MicrosoftQuickAuthSwiftSupport.podspec
+++ b/MicrosoftQuickAuthSwiftSupport.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                  = 'MicrosoftQuickAuthSwiftSupport'
   s.version               = '0.0.5'
-  s.summary               = 'Add Swift-UI support for MicrosoftQuickAuth.'
+  s.summary               = 'Add SwiftUI support for MicrosoftQuickAuth.'
   s.homepage              = 'https://github.com/microsoft/quick-authentication/blob/main/docs/quick-authentication-ios-how-to.md'
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.authors               = { 'Microsoft' => 'minggangwang@microsoft.com' }

--- a/iOS/MSQASignInSwift/MSQASignInButton.swift
+++ b/iOS/MSQASignInSwift/MSQASignInButton.swift
@@ -1,0 +1,157 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import Foundation
+import SwiftUI
+
+/// Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public struct MSQASignInButton: View {
+  /// An object containing the customization to the button.
+  @ObservedObject public var viewModel: MSQASignInButtonViewModel
+  private let action: () -> Void
+
+  /// Creates an instance of Microsoft Quick Auth sign in button.
+  /// - parameter viewModel: An instance of `MSQASignInButtonViewModel` with customization about the button's type, theme, size, etc.
+  ///     Defaults to `MSQASignInButtonViewModel` with its standard defaults.
+  /// - parameter action: A closure to be executed on button press event.
+  ///     Defaults to no-op.
+  public init(
+    viewModel: MSQASignInButtonViewModel = MSQASignInButtonViewModel(),
+    action: @escaping () -> Void = {}
+  ) {
+    self.viewModel = viewModel
+    self.action = action
+  }
+
+  /// A convenience initializer to create a Microsoft Quick Auth sign in button with type, theme, size, etc.
+  /// - parameter type: The `MSQASignInButtonType` to use.
+  ///     Defaults to `.standard`.
+  /// - parameter theme: The `MSQASignInButtonTheme` to use.
+  ///     Defaults to `.light`.
+  /// - parameter size: The `MSQASignInButtonSize` to use.
+  ///     Defaults to `.large`.
+  /// - parameter text: The `MSQASignInButtonText` to use.
+  ///     Defaults to `.signInWith`.
+  /// - parameter shape: The `MSQASignInButtonShape` to use.
+  ///     Defaults to `.rectangular`.
+  /// - parameter layout: The `MSQASignInButtonLayout` to use.
+  ///     Defaults to `.logoTextLeft`.
+  /// - parameter state: The `MSQASignInButtonState` to use.
+  ///     Defaults to `.normal`.
+  /// - parameter action: A closure to be executed on button press event.
+  ///     Defaults to no-op.
+  public init(
+    type: MSQASignInButtonType = .standard,
+    theme: MSQASignInButtonTheme = .light,
+    size: MSQASignInButtonSize = .large,
+    text: MSQASignInButtonText = .signInWith,
+    shape: MSQASignInButtonShape = .rectangular,
+    layout: MSQASignInButtonLayout = .logoTextLeft,
+    state: MSQASignInButtonState = .normal,
+    action: @escaping () -> Void = {}
+  ) {
+    let viewModel = MSQASignInButtonViewModel(
+      type: type, theme: theme, size: size, text: text, shape: shape, layout: layout, state: state)
+    self.init(viewModel: viewModel, action: action)
+  }
+
+  public var body: some View {
+    Button(action: action) {
+      switch viewModel.type {
+      case .standard:
+        switch viewModel.layout {
+        case .logoTextLeft: logoTextLeadingView
+        case .logoLeftTextCenter: logoLeadingTextCenterView
+        case .logoTextCenter: logoTextCenterView
+        }
+      case .icon: iconView
+      }
+    }
+    .font(viewModel.buttonStyle.font)
+    .buttonStyle(viewModel.buttonStyle)
+    .simultaneousGesture(
+      DragGesture(minimumDistance: 0)
+        .onChanged({ _ in viewModel.state = .pressed })
+        .onEnded({ _ in viewModel.state = .normal })
+    )
+  }
+
+  private var logoTextLeadingView: some View {
+    return HStack(alignment: .center, spacing: 0) {
+      iconView
+        .padding([.leading, .trailing], MSQASignInButtonElementPadding)
+      Text(MSQASignInButtonHelper.localizedString(forText: viewModel.text))
+        .fixedSize()
+        .frame(
+          width: viewModel.buttonStyle.textWidth, height: viewModel.buttonStyle.buttonHeight,
+          alignment: .leading)
+      Spacer()
+    }
+  }
+
+  private var logoLeadingTextCenterView: some View {
+    return HStack(alignment: .center, spacing: 0) {
+      iconView
+        .padding(.leading, MSQASignInButtonElementPadding)
+      Spacer()
+      Text(MSQASignInButtonHelper.localizedString(forText: viewModel.text))
+        .fixedSize()
+        .frame(
+          width: viewModel.buttonStyle.textWidth, height: viewModel.buttonStyle.buttonHeight,
+          alignment: .leading)
+      Spacer()
+    }
+  }
+
+  private var logoTextCenterView: some View {
+    return HStack(alignment: .center, spacing: 0) {
+      Spacer()
+      iconView
+        .padding(.trailing, MSQASignInButtonElementPadding)
+      Text(MSQASignInButtonHelper.localizedString(forText: viewModel.text))
+        .fixedSize()
+        .frame(
+          width: viewModel.buttonStyle.textWidth, height: viewModel.buttonStyle.buttonHeight,
+          alignment: .leading)
+      Spacer()
+    }
+  }
+
+  private var iconView: Image {
+    guard
+      let iconURL = MSQASignInButtonHelper.url(
+        forResource: viewModel.buttonStyle.iconName, withExtension: MSQASignInButtonIconExtension)
+    else {
+      fatalError("Failed to load Microsoft brand logo")
+    }
+    guard let iconImage = UIImage(contentsOfFile: iconURL.path) else {
+      fatalError("Failed to load Microsoft brand logo")
+    }
+    return Image(uiImage: iconImage)
+  }
+}

--- a/iOS/MSQASignInSwift/MSQASignInButtonHelper.swift
+++ b/iOS/MSQASignInSwift/MSQASignInButtonHelper.swift
@@ -1,0 +1,92 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import Foundation
+import MicrosoftQuickAuth
+
+let MicrosoftQuickAuthBundleName: String = "MicrosoftQuickAuth"
+let MicrosoftQuickAuthBundleType: String = "bundle"
+
+let MSQASignInButtonLocalizedStringTableName: String = "Localizable"
+let MSQASignInButtonSignInWithKey: String = "msqa_signin_with_text"
+let MSQASignInButtonSignUpWithKey: String = "msqa_signup_with_text"
+let MSQASignInButtonContinueWithKey: String = "msqa_continue_with_text"
+let MSQASignInButtonSignInKey: String = "msqa_signin_text"
+
+let MSQASignInButtonSignInWithDefaultString: String = "Sign in with Microsoft"
+let MSQASignInButtonSignUpWithDefaultString: String = "Sign up with Microsoft"
+let MSQASignInButtonContinueWithDefaultString: String = "Continue with Microsoft"
+let MSQASignInButtonSignInDefaultString: String = "Sign in"
+
+@available(iOS 13.0, *)
+struct MSQASignInButtonHelper {
+  static func frameworkBundle() -> Bundle? {
+    if let mainBundlePath = Bundle.main.path(
+      forResource: MicrosoftQuickAuthBundleName, ofType: MicrosoftQuickAuthBundleType)
+    {
+      return Bundle(path: mainBundlePath)
+    }
+    let classBundle = Bundle(for: MSQASignInClient.self)
+    guard
+      let classBundlePath = classBundle.path(
+        forResource: MicrosoftQuickAuthBundleName, ofType: MicrosoftQuickAuthBundleType)
+    else {
+      return nil
+    }
+    return Bundle(path: classBundlePath)
+  }
+
+  static func url(forResource name: String?, withExtension ext: String?) -> URL? {
+    return frameworkBundle()?.url(forResource: name, withExtension: ext)
+  }
+
+  static func localizedString(forText text: MSQASignInButtonText) -> String {
+    var key: String
+    var defaultString: String
+    switch text {
+    case .signInWith:
+      key = MSQASignInButtonSignInWithKey
+      defaultString = MSQASignInButtonSignInWithDefaultString
+    case .signUpWith:
+      key = MSQASignInButtonSignUpWithKey
+      defaultString = MSQASignInButtonSignUpWithDefaultString
+    case .continueWith:
+      key = MSQASignInButtonContinueWithKey
+      defaultString = MSQASignInButtonContinueWithDefaultString
+    case .signIn:
+      key = MSQASignInButtonSignInKey
+      defaultString = MSQASignInButtonSignInDefaultString
+    }
+    guard
+      let string = frameworkBundle()?.localizedString(
+        forKey: key, value: nil, table: MSQASignInButtonLocalizedStringTableName)
+    else {
+      return defaultString
+    }
+    return string
+  }
+}

--- a/iOS/MSQASignInSwift/MSQASignInButtonViewModel.swift
+++ b/iOS/MSQASignInSwift/MSQASignInButtonViewModel.swift
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import Foundation
+
+/// A view model for Microsoft Quick Auth sign in button publishing changes for the button's type, theme, size, etc.
+@available(iOS 13.0, *)
+public class MSQASignInButtonViewModel: ObservableObject {
+  @Published public var type: MSQASignInButtonType
+  @Published public var theme: MSQASignInButtonTheme
+  @Published public var size: MSQASignInButtonSize
+  @Published public var text: MSQASignInButtonText
+  @Published public var shape: MSQASignInButtonShape
+  @Published public var layout: MSQASignInButtonLayout
+  @Published public var state: MSQASignInButtonState
+
+  /// Creates an instance of the view model for Microsoft Quick Auth sign in button.
+  /// - parameter type: The `MSQASignInButtonType` to use.
+  ///     Defaults to `.standard`.
+  /// - parameter theme: The `MSQASignInButtonTheme` to use.
+  ///     Defaults to `.light`.
+  /// - parameter size: The `MSQASignInButtonSize` to use.
+  ///     Defaults to `.large`.
+  /// - parameter text: The `MSQASignInButtonText` to use.
+  ///     Defaults to `.signInWith`.
+  /// - parameter shape: The `MSQASignInButtonShape` to use.
+  ///     Defaults to `.rectangular`.
+  /// - parameter layout: The `MSQASignInButtonLayout` to use.
+  ///     Defaults to `.logoTextLeft`.
+  /// - parameter state: The `MSQASignInButtonState` to use.
+  ///     Defaults to `.normal`.
+  public init(
+    type: MSQASignInButtonType = .standard,
+    theme: MSQASignInButtonTheme = .light,
+    size: MSQASignInButtonSize = .large,
+    text: MSQASignInButtonText = .signInWith,
+    shape: MSQASignInButtonShape = .rectangular,
+    layout: MSQASignInButtonLayout = .logoTextLeft,
+    state: MSQASignInButtonState = .normal
+  ) {
+    self.type = type
+    self.theme = theme
+    self.size = size
+    self.text = text
+    self.shape = shape
+    self.layout = layout
+    self.state = state
+  }
+
+  var buttonStyle: MSQASignInButtonStyle {
+    return MSQASignInButtonStyle(
+      type: type, theme: theme, size: size, text: text, shape: shape, layout: layout, state: state)
+  }
+}

--- a/iOS/MSQASignInSwift/MSQASignInCustomization.swift
+++ b/iOS/MSQASignInSwift/MSQASignInCustomization.swift
@@ -1,0 +1,288 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import Foundation
+import SwiftUI
+
+let MSQASignInButtonFontName: String = "SegoeUI-SemiBold"
+let MSQASignInButtonFontExtension: String = "ttf"
+
+let MSQASignInButtonLargeIconName: String = "Microsoft-Brand-20"
+let MSQASignInButtonMediumIconName: String = "Microsoft-Brand-16"
+let MSQASignInButtonSmallIconName: String = "Microsoft-Brand-12"
+let MSQASignInButtonIconExtension: String = "png"
+
+let MSQASignInButtonLargeFontSize: CGFloat = 16
+let MSQASignInButtonMediumFontSize: CGFloat = 14
+let MSQASignInButtonSmallFontSize: CGFloat = 12
+
+let MSQASignInButtonLargeButtonHeight: CGFloat = 42
+let MSQASignInButtonMediumButtonHeight: CGFloat = 36
+let MSQASignInButtonSmallButtonHeight: CGFloat = 28
+
+let MSQASignInButtonLargeIconSize: CGFloat = 20
+let MSQASignInButtonMediumIconSize: CGFloat = 16
+let MSQASignInButtonSmallIconSize: CGFloat = 12
+
+let MSQASignInButtonBorderWidth: CGFloat = 1
+let MSQASignInButtonElementPadding: CGFloat = 12
+let MSQASignInButtonRoundedCornerRadius: CGFloat = 4
+
+let MSQASignInButtonNormalBackgroundColorLight: Int = 0xffff_ffff
+let MSQASignInButtonNormalBackgroundColorDark: Int = 0x2f2f_2fff
+let MSQASignInButtonNormalBorderColorLight: Int = 0xd6d6_d6ff
+let MSQASignInButtonNormalBorderColorDark: Int = 0x2f2f_2fff
+
+let MSQASignInButtonPressedBackgroundColorLight: Int = 0xefef_efff
+let MSQASignInButtonPressedBackgroundColorDark: Int = 0x2727_27ff
+let MSQASignInButtonPressedBorderColorLight: Int = 0xd6d6_d6ff
+let MSQASignInButtonPressedBorderColorDark: Int = 0x2727_27ff
+
+let MSQASignInButtonTextColorLight: Int = 0x3231_30ff
+let MSQASignInButtonTextColorDark: Int = 0xffff_ffff
+
+/// Types supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonType: String, Identifiable, CaseIterable {
+  case standard
+  case icon
+  public var id: String { rawValue }
+}
+
+/// Types supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonTheme: String, Identifiable, CaseIterable {
+  case light
+  case dark
+  public var id: String { rawValue }
+}
+
+/// Sizes supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonSize: String, Identifiable, CaseIterable {
+  case large
+  case medium
+  case small
+  public var id: String { rawValue }
+}
+
+/// Texts supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonText: String, Identifiable, CaseIterable {
+  case signInWith
+  case signUpWith
+  case continueWith
+  case signIn
+  public var id: String { rawValue }
+}
+
+/// Shapes supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonShape: String, Identifiable, CaseIterable {
+  case rectangular
+  case rounded
+  case pill
+  public var id: String { rawValue }
+}
+
+/// Layouts supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonLayout: String, Identifiable, CaseIterable {
+  case logoTextLeft
+  case logoLeftTextCenter
+  case logoTextCenter
+  public var id: String { rawValue }
+}
+
+/// States supported by Microsoft Quick Auth sign in button.
+@available(iOS 13.0, *)
+public enum MSQASignInButtonState: String, Identifiable, CaseIterable {
+  case normal
+  case pressed
+  public var id: String { rawValue }
+}
+
+@available(iOS 13.0, *)
+struct MSQASignInButtonStyle: ButtonStyle {
+  let type: MSQASignInButtonType
+  let theme: MSQASignInButtonTheme
+  let size: MSQASignInButtonSize
+  let text: MSQASignInButtonText
+  let shape: MSQASignInButtonShape
+  let layout: MSQASignInButtonLayout
+  let state: MSQASignInButtonState
+
+  public var font: Font {
+    return Font(uiFont)
+  }
+
+  private var uiFont: UIFont {
+    let calculatedFontSize = fontSize
+    if let registeredFont = UIFont(name: MSQASignInButtonFontName, size: calculatedFontSize) {
+      return registeredFont
+    }
+    guard
+      let fontURL = MSQASignInButtonHelper.url(
+        forResource: MSQASignInButtonFontName, withExtension: MSQASignInButtonFontExtension),
+      let fontDataProvider = CGDataProvider(filename: fontURL.path),
+      let font = CGFont(fontDataProvider)
+    else {
+      return UIFont.systemFont(ofSize: calculatedFontSize, weight: .bold)
+    }
+    guard CTFontManagerRegisterGraphicsFont(font, nil) else {
+      return UIFont.systemFont(ofSize: calculatedFontSize, weight: .bold)
+    }
+    if let registeredFont = UIFont(name: MSQASignInButtonFontName, size: calculatedFontSize) {
+      return registeredFont
+    }
+    return UIFont.systemFont(ofSize: calculatedFontSize, weight: .bold)
+  }
+
+  public var fontSize: CGFloat {
+    switch size {
+    case .large: return MSQASignInButtonLargeFontSize
+    case .medium: return MSQASignInButtonMediumFontSize
+    case .small: return MSQASignInButtonSmallFontSize
+    }
+  }
+
+  public var iconName: String {
+    switch size {
+    case .large: return MSQASignInButtonLargeIconName
+    case .medium: return MSQASignInButtonMediumIconName
+    case .small: return MSQASignInButtonSmallIconName
+    }
+  }
+
+  private var iconSize: CGFloat {
+    switch size {
+    case .large: return MSQASignInButtonLargeIconSize
+    case .medium: return MSQASignInButtonMediumIconSize
+    case .small: return MSQASignInButtonSmallIconSize
+    }
+  }
+
+  public var textWidth: CGFloat {
+    let string = MSQASignInButtonHelper.localizedString(forText: text) as NSString
+    let size = CGSize(width: .max, height: .max)
+    let font = uiFont as Any
+    let rect = string.boundingRect(with: size, attributes: [.font: font], context: nil)
+    return rect.width
+  }
+
+  private var textColor: Color {
+    switch theme {
+    case .light: return colorFromHex(hex: MSQASignInButtonTextColorLight)
+    case .dark: return colorFromHex(hex: MSQASignInButtonTextColorDark)
+    }
+  }
+
+  private struct ButtonWidthRange {
+    let min, max: CGFloat
+  }
+
+  private var buttonWidthRange: ButtonWidthRange {
+    if type == .icon {
+      let fixedWidth = buttonHeight
+      return ButtonWidthRange(min: fixedWidth, max: fixedWidth)
+    }
+    let min = iconSize + textWidth + MSQASignInButtonElementPadding * 3
+    return ButtonWidthRange(min: min, max: .infinity)
+  }
+
+  public var buttonHeight: CGFloat {
+    switch size {
+    case .large: return MSQASignInButtonLargeButtonHeight
+    case .medium: return MSQASignInButtonMediumButtonHeight
+    case .small: return MSQASignInButtonSmallButtonHeight
+    }
+  }
+
+  private var buttonColor: Color {
+    switch theme {
+    case .light:
+      switch state {
+      case .normal: return colorFromHex(hex: MSQASignInButtonNormalBackgroundColorLight)
+      case .pressed: return colorFromHex(hex: MSQASignInButtonPressedBackgroundColorLight)
+      }
+    case .dark:
+      switch state {
+      case .normal: return colorFromHex(hex: MSQASignInButtonNormalBackgroundColorDark)
+      case .pressed: return colorFromHex(hex: MSQASignInButtonPressedBackgroundColorDark)
+      }
+    }
+  }
+
+  private var borderColor: Color {
+    switch theme {
+    case .light:
+      switch state {
+      case .normal: return colorFromHex(hex: MSQASignInButtonNormalBorderColorLight)
+      case .pressed: return colorFromHex(hex: MSQASignInButtonPressedBorderColorLight)
+      }
+    case .dark:
+      switch state {
+      case .normal: return colorFromHex(hex: MSQASignInButtonNormalBorderColorDark)
+      case .pressed: return colorFromHex(hex: MSQASignInButtonPressedBorderColorDark)
+      }
+    }
+  }
+
+  private var radius: CGFloat {
+    switch shape {
+    case .rectangular: return 0
+    case .rounded: return MSQASignInButtonRoundedCornerRadius
+    case .pill: return (buttonHeight - MSQASignInButtonBorderWidth) / 2
+    }
+  }
+
+  private func colorFromHex(hex: Int) -> Color {
+    return Color(
+      red: Double((hex & 0xff00_0000) >> 24) / 255,
+      green: Double((hex & 0x00ff_0000) >> 16) / 255,
+      blue: Double((hex & 0x0000_ff00) >> 8) / 255,
+      opacity: Double((hex & 0x0000_00ff) >> 0) / 255)
+  }
+
+  func makeBody(configuration: Configuration) -> some View {
+    let calculatedButtonHeight = buttonHeight
+    let calculatedButtonWidthRange = buttonWidthRange
+    let calculatedRadius = radius
+    configuration.label
+      .frame(
+        minWidth: calculatedButtonWidthRange.min, maxWidth: calculatedButtonWidthRange.max,
+        minHeight: calculatedButtonHeight, maxHeight: calculatedButtonHeight
+      )
+      .background(buttonColor)
+      .foregroundColor(textColor)
+      .cornerRadius(calculatedRadius)
+      .overlay(
+        RoundedRectangle(cornerRadius: calculatedRadius)
+          .stroke(borderColor, lineWidth: MSQASignInButtonBorderWidth)
+      )
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo.xcodeproj/project.pbxproj
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,413 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0220D97E29346C22002025A0 /* MSQASignInDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0220D97D29346C22002025A0 /* MSQASignInDemoApp.swift */; };
+		0220D98229346C23002025A0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0220D98129346C23002025A0 /* Assets.xcassets */; };
+		0220D98529346C23002025A0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0220D98429346C23002025A0 /* Preview Assets.xcassets */; };
+		0220D98C29346C53002025A0 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0220D98B29346C53002025A0 /* SignInView.swift */; };
+		7206902584CDE1731B24C89C /* Pods_MSQASignInDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F0CEC19C2BDA7F80BE443AB /* Pods_MSQASignInDemo.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0220D97A29346C22002025A0 /* MSQASignInDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MSQASignInDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0220D97D29346C22002025A0 /* MSQASignInDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSQASignInDemoApp.swift; sourceTree = "<group>"; };
+		0220D98129346C23002025A0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0220D98429346C23002025A0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		0220D98B29346C53002025A0 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		0F0CEC19C2BDA7F80BE443AB /* Pods_MSQASignInDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MSQASignInDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		83A0675116B90A6886834EAB /* Pods-MSQASignInDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSQASignInDemo.release.xcconfig"; path = "Target Support Files/Pods-MSQASignInDemo/Pods-MSQASignInDemo.release.xcconfig"; sourceTree = "<group>"; };
+		B34A278854A21A5BBAEAEC9A /* Pods-MSQASignInDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSQASignInDemo.debug.xcconfig"; path = "Target Support Files/Pods-MSQASignInDemo/Pods-MSQASignInDemo.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0220D97729346C22002025A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7206902584CDE1731B24C89C /* Pods_MSQASignInDemo.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0220D97129346C22002025A0 = {
+			isa = PBXGroup;
+			children = (
+				0220D97C29346C22002025A0 /* MSQASignInDemo */,
+				0220D97B29346C22002025A0 /* Products */,
+				1AC61EE9A0B5F6AAD13D2017 /* Pods */,
+				1074FA52A62530FAD9655808 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0220D97B29346C22002025A0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0220D97A29346C22002025A0 /* MSQASignInDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0220D97C29346C22002025A0 /* MSQASignInDemo */ = {
+			isa = PBXGroup;
+			children = (
+				0220D97D29346C22002025A0 /* MSQASignInDemoApp.swift */,
+				0220D98B29346C53002025A0 /* SignInView.swift */,
+				0220D98129346C23002025A0 /* Assets.xcassets */,
+				0220D98329346C23002025A0 /* Preview Content */,
+			);
+			path = MSQASignInDemo;
+			sourceTree = "<group>";
+		};
+		0220D98329346C23002025A0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				0220D98429346C23002025A0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		1074FA52A62530FAD9655808 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0F0CEC19C2BDA7F80BE443AB /* Pods_MSQASignInDemo.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1AC61EE9A0B5F6AAD13D2017 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B34A278854A21A5BBAEAEC9A /* Pods-MSQASignInDemo.debug.xcconfig */,
+				83A0675116B90A6886834EAB /* Pods-MSQASignInDemo.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0220D97929346C22002025A0 /* MSQASignInDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0220D98829346C23002025A0 /* Build configuration list for PBXNativeTarget "MSQASignInDemo" */;
+			buildPhases = (
+				487B0B17ADD6E983CD700619 /* [CP] Check Pods Manifest.lock */,
+				0220D97629346C22002025A0 /* Sources */,
+				0220D97729346C22002025A0 /* Frameworks */,
+				0220D97829346C22002025A0 /* Resources */,
+				3FF7FE0B8597018F2BB97678 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MSQASignInDemo;
+			productName = MSQASignInDemo;
+			productReference = 0220D97A29346C22002025A0 /* MSQASignInDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0220D97229346C22002025A0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					0220D97929346C22002025A0 = {
+						CreatedOnToolsVersion = 14.1;
+					};
+				};
+			};
+			buildConfigurationList = 0220D97529346C22002025A0 /* Build configuration list for PBXProject "MSQASignInDemo" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0220D97129346C22002025A0;
+			productRefGroup = 0220D97B29346C22002025A0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0220D97929346C22002025A0 /* MSQASignInDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0220D97829346C22002025A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0220D98529346C23002025A0 /* Preview Assets.xcassets in Resources */,
+				0220D98229346C23002025A0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3FF7FE0B8597018F2BB97678 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MSQASignInDemo/Pods-MSQASignInDemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MSQASignInDemo/Pods-MSQASignInDemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MSQASignInDemo/Pods-MSQASignInDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		487B0B17ADD6E983CD700619 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MSQASignInDemo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0220D97629346C22002025A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0220D98C29346C53002025A0 /* SignInView.swift in Sources */,
+				0220D97E29346C22002025A0 /* MSQASignInDemoApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0220D98629346C23002025A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0220D98729346C23002025A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0220D98929346C23002025A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B34A278854A21A5BBAEAEC9A /* Pods-MSQASignInDemo.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"MSQASignInDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSQASignInDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0220D98A29346C23002025A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 83A0675116B90A6886834EAB /* Pods-MSQASignInDemo.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"MSQASignInDemo/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSQASignInDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0220D97529346C22002025A0 /* Build configuration list for PBXProject "MSQASignInDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0220D98629346C23002025A0 /* Debug */,
+				0220D98729346C23002025A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0220D98829346C23002025A0 /* Build configuration list for PBXNativeTarget "MSQASignInDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0220D98929346C23002025A0 /* Debug */,
+				0220D98A29346C23002025A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0220D97229346C22002025A0 /* Project object */;
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/Contents.json
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/MSQASignInDemoApp.swift
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/MSQASignInDemoApp.swift
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import SwiftUI
+
+@main
+struct MSQASignInDemoApp: App {
+  var body: some Scene {
+    WindowGroup {
+      SignInView()
+    }
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/SignInView.swift
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/MSQASignInDemo/SignInView.swift
@@ -1,0 +1,115 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//-----------------------------------------------------------------------------
+
+import MSQASignInSwift
+import SwiftUI
+
+struct SignInView: View {
+  @ObservedObject var signInButtonViewModel = MSQASignInButtonViewModel()
+
+  var body: some View {
+    Spacer()
+    MSQASignInButton(
+      viewModel: signInButtonViewModel,
+      action: { () -> Void in
+        // Handle sign in button click event here.
+      }
+    )
+    .accessibilityIdentifier("MSQASignInButton")
+    .accessibility(hint: Text("Sign in with Microsoft button."))
+    .padding()
+    VStack {
+      HStack {
+        Text("Button type:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.type) {
+          ForEach(MSQASignInButtonType.allCases) { type in
+            Text(type.rawValue.capitalized)
+              .tag(MSQASignInButtonType(rawValue: type.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+      HStack {
+        Text("Button theme:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.theme) {
+          ForEach(MSQASignInButtonTheme.allCases) { theme in
+            Text(theme.rawValue.capitalized)
+              .tag(MSQASignInButtonTheme(rawValue: theme.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+      HStack {
+        Text("Button size:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.size) {
+          ForEach(MSQASignInButtonSize.allCases) { size in
+            Text(size.rawValue.capitalized)
+              .tag(MSQASignInButtonSize(rawValue: size.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+      HStack {
+        Text("Button text:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.text) {
+          ForEach(MSQASignInButtonText.allCases) { text in
+            Text(text.rawValue.capitalized)
+              .tag(MSQASignInButtonText(rawValue: text.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+      HStack {
+        Text("Button shape:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.shape) {
+          ForEach(MSQASignInButtonShape.allCases) { shape in
+            Text(shape.rawValue.capitalized)
+              .tag(MSQASignInButtonShape(rawValue: shape.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+      HStack {
+        Text("Button layout:")
+          .padding(.leading)
+        Picker("", selection: $signInButtonViewModel.layout) {
+          ForEach(MSQASignInButtonLayout.allCases) { layout in
+            Text(layout.rawValue.capitalized)
+              .tag(MSQASignInButtonLayout(rawValue: layout.rawValue)!)
+          }
+        }
+        Spacer()
+      }
+    }.pickerStyle(.segmented)
+    Spacer()
+  }
+}

--- a/iOS/SampleApp/Swift/MSQASignInDemo/Podfile
+++ b/iOS/SampleApp/Swift/MSQASignInDemo/Podfile
@@ -1,0 +1,6 @@
+platform :ios, '13.0'
+
+target 'MSQASignInDemo' do
+  use_frameworks!
+  pod 'MicrosoftQuickAuthSwiftSupport', :path => '../../../../' 
+end


### PR DESCRIPTION
**This PR:**
* Add SwiftUI support for MicrosoftQuickAuth.
  * New pod `MicrosoftQuickAuthSwiftSupport` is introduced.
  * SwiftUI version of `MSQASignInButton` is provided by the new pod, with the same customization ability as the UIKit one: type, theme, size, text, shape, layout, state.
* Add a sample app that uses the SwiftUI version of `MSQASignInButton`.