### PR TITLE
[iOS] Correct the key to get the localized string

### DIFF
--- a/iOS/MSQASignIn/src/MSQASignInButton.m
+++ b/iOS/MSQASignIn/src/MSQASignInButton.m
@@ -624,7 +624,7 @@ typedef NS_ENUM(NSUInteger, MSQASignInButtonState) {
                         table:kStringsTableName];
   case kMSQASignInButtonTextSignIn:
     return [[MSQASignInButton getFrameworkBundle]
-        localizedStringForKey:@"msqa_signin_with_text"
+        localizedStringForKey:@"msqa_signin_text"
                         value:nil
                         table:kStringsTableName];
   }


### PR DESCRIPTION
This patch corrects the key used to get the localized string.

Related work item: #50