### PR TITLE
[iOS][a11y] Set proper role for Microsoft sign in button

### DIFF
--- a/iOS/MSQASignIn/src/MSQASignInButton.m
+++ b/iOS/MSQASignIn/src/MSQASignInButton.m
@@ -151,6 +151,7 @@ typedef NS_ENUM(NSUInteger, MSQASignInButtonState) {
   _logo = kMSQASignInButtonLogoLeft;
   _buttonState = kMSQASignInButtonStateNormal;
   self.isAccessibilityElement = YES;
+  self.accessibilityTraits = UIAccessibilityTraitButton;
   self.accessibilityLabel = [self buttonTextString];
 
   [self addTarget:self


### PR DESCRIPTION
This patch sets `UIAccessibilityTraitButton` to the Microsoft sign in button property `accessibilityTraits`, thus the Voiceover can recognize it as a button.

Related work item: 42504461