### PR TITLE
[iOS][a11y] Continue to sign in interactively in any case

### DIFF
--- a/iOS/MSQASignIn/src/MSQASignInClient.m
+++ b/iOS/MSQASignIn/src/MSQASignInClient.m
@@ -423,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
 
                          if (error) {
                            [MSQALogger.sharedInstance
-                               logWithLevel:MSQALogLevelError
+                               logWithLevel:MSQALogLevelInfo
                                      format:error.domain];
                          }
                          MSQAInteractiveTokenParameters *interactiveParams =

--- a/iOS/MSQASignIn/src/MSQASignInClient.m
+++ b/iOS/MSQASignIn/src/MSQASignInClient.m
@@ -420,14 +420,12 @@ NS_ASSUME_NONNULL_BEGIN
 
                            return;
                          }
-                         if (error &&
-                             error.code != MSALErrorInteractionRequired) {
-                           [MSQASignInClient callBlockOnMainThread:^{
-                             completionBlock(nil, error);
-                           }];
-                           return;
-                         }
 
+                         if (error) {
+                           [MSQALogger.sharedInstance
+                               logWithLevel:MSQALogLevelError
+                                     format:error.domain];
+                         }
                          MSQAInteractiveTokenParameters *interactiveParams =
                              [MSQASignInClient
                                  createInteractiveTokenParametersWithController:


### PR DESCRIPTION
When testing the a11y functionalities, we found a bug that the Microsoft sign-in button could become irresponsive in some case on iPhone device.

After investigating, this issue occurs when the device installs MS authenticator where an AAD has been added, in this case, acquiring the token silently will lead to an error, saying "Multiple accounts found in cache". Per current implementation, the MSQASignInClient will stop to sign in and return.

This patch changes this behavior to continue to sign in interactively if any error happens during acquiring token silently, which is more reasonable because we should try to acquire the token as much as possible instead of just stopping the process.

https://microsoft.visualstudio.com/Edge/_workitems/edit/42508980/

Related work item: 42508980