### PR TITLE
[iOS][a11y] Increase the font size for accessibility larger text

### DIFF
--- a/iOS/MSQASignIn/src/MSQASignInButton.m
+++ b/iOS/MSQASignIn/src/MSQASignInButton.m
@@ -58,7 +58,9 @@ static const CGFloat kSmallButtonHeight = 28;
 
 static const CGFloat kStandardCornerRadius = 4;
 
-static const CGFloat kFontSizeDeltaForAccessibilityLarger = 4;
+/// The ratio of font size used for accessibility larger text.
+static const CGFloat kFontSizeRatioForAccessibilityLarger = 1.25;
+
 static const CGFloat kLargeTextSize = 16;
 static const CGFloat kMediumTextSize = 14;
 static const CGFloat kSmallTextSize = 12;
@@ -669,7 +671,7 @@ typedef NS_ENUM(NSUInteger, MSQASignInButtonState) {
 - (UIFont *)buttonTextFont {
   CGFloat size =
       self.isAccessibilityLargerEnabled
-          ? kFontSizeDeltaForAccessibilityLarger + [self buttonTextFontSize]
+          ? kFontSizeRatioForAccessibilityLarger * [self buttonTextFontSize]
           : [self buttonTextFontSize];
   // We only try to apply the SegoeUI-SemiBold font for English, other languages
   // use the system default.


### PR DESCRIPTION
Per accessibility requirement, we should increase the size of the button text, when the larger text is enabled from
Settings=>Accessibility=>Display & Text Size=>Larger Text.

This patch implements listen to the UIContentSizeCategoryDidChangeNotification event, and enlarge the font size if necessary.

Manually tested.

- Italian

https://user-images.githubusercontent.com/6469275/212639636-eff3b476-d31b-4993-aa0c-3aa63659d5f8.mov

- French

https://user-images.githubusercontent.com/6469275/212639758-19362cbf-dfef-4c7a-bf1a-f82b5982abcc.mov

Related work item: 42509074