### PR TITLE
[iOS] Correct the objc sample path for ESRP pipeline

### DIFF
--- a/iOS/azure-pipelines.yml
+++ b/iOS/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       scheme: 'SampleAppiOS'
       sdk: 'iphoneos'
       configuration: 'Debug'
-      xcWorkspacePath: 'iOS/SampleApp/QuickAuthSample.xcworkspace'
+      xcWorkspacePath: 'iOS/SampleApp/ObjC/QuickAuthSample/QuickAuthSample.xcworkspace'
       xcodeVersion: 'default'
       packageApp: true
       signingOption: default


### PR DESCRIPTION
As the objc sample has been moved to a new path, this patch updates the path used in ESRP Codesign pipeline.